### PR TITLE
Fix farming batch creation validation

### DIFF
--- a/IRasRag.API/Controllers/FarmingBatchController.cs
+++ b/IRasRag.API/Controllers/FarmingBatchController.cs
@@ -124,6 +124,7 @@ namespace IRasRag.API.Controllers
                         new { result.Message, result.Data }
                     ),
                     ResultType.BadRequest => BadRequest(new { result.Message }),
+                    ResultType.Conflict => Conflict(new { result.Message }),
                     _ => StatusCode(500, new { result.Message }),
                 };
             }

--- a/IRasRag.Application/Common/Mappings/FarmingBatchProfile.cs
+++ b/IRasRag.Application/Common/Mappings/FarmingBatchProfile.cs
@@ -17,8 +17,16 @@ namespace IRasRag.Application.Common.Mappings
                     opt => opt.MapFrom(src => src.CurrentStageConfigId)
                 )
                 .ForMember(
+                    dest => dest.SpeciesId,
+                    opt => opt.MapFrom(src => src.CurrentStageConfig.SpeciesId)
+                )
+                .ForMember(
                     dest => dest.SpeciesName,
                     opt => opt.MapFrom(src => src.CurrentStageConfig.Species.Name)
+                )
+                .ForMember(
+                    dest => dest.GrowthStageId,
+                    opt => opt.MapFrom(src => src.CurrentStageConfig.GrowthStageId)
                 )
                 .ForMember(
                     dest => dest.StageName,

--- a/IRasRag.Application/DTOs/FarmingBatchDto.cs
+++ b/IRasRag.Application/DTOs/FarmingBatchDto.cs
@@ -46,11 +46,12 @@ namespace IRasRag.Application.DTOs
         [MaxLength(255, ErrorMessage = "Tên lô nuôi không được vượt quá 255 ký tự")]
         public string Name { get; set; } = string.Empty;
 
-        [Required(ErrorMessage = "SpeciesId là bắt buộc")]
-        public Guid SpeciesId { get; set; }
+        [Required(ErrorMessage = "SpeciesStageConfigId là bắt buộc")]
+        public Guid? SpeciesStageConfigId { get; set; }
 
-        [Required(ErrorMessage = "GrowthStageId là bắt buộc")]
-        public Guid GrowthStageId { get; set; }
+        public Guid? SpeciesId { get; set; }
+
+        public Guid? GrowthStageId { get; set; }
 
         [Required(ErrorMessage = "Ngày bắt đầu là bắt buộc")]
         public DateTime StartDate { get; set; }

--- a/IRasRag.Application/Services/Implementations/FarmingBatchService.cs
+++ b/IRasRag.Application/Services/Implementations/FarmingBatchService.cs
@@ -196,42 +196,88 @@ namespace IRasRag.Application.Services.Implementations
                     }
                 }
 
-                // Validate Species exists
-                var speciesRepo = _unitOfWork.GetRepository<Species>();
-                var speciesExists = await speciesRepo.AnyAsync(s => s.Id == createDto.SpeciesId);
-                if (!speciesExists)
-                {
-                    return Result<FarmingBatchDto>.Failure(
-                        "Loài cá không tồn tại",
-                        ResultType.BadRequest
-                    );
-                }
-
-                // Validate GrowthStage exists
-                var growthStageRepo = _unitOfWork.GetRepository<GrowthStage>();
-                var growthStageExists = await growthStageRepo.AnyAsync(gs =>
-                    gs.Id == createDto.GrowthStageId
-                );
-                if (!growthStageExists)
-                {
-                    return Result<FarmingBatchDto>.Failure(
-                        "Giai đoạn tăng trưởng không tồn tại",
-                        ResultType.BadRequest
-                    );
-                }
-
-                // Resolve SpeciesStageConfig from Species + GrowthStage
                 var stageConfigRepo = _unitOfWork.GetRepository<SpeciesStageConfig>();
-                var stageConfig = await stageConfigRepo.FirstOrDefaultAsync(sc =>
-                    sc.SpeciesId == createDto.SpeciesId
-                    && sc.GrowthStageId == createDto.GrowthStageId
-                );
-                if (stageConfig == null)
+                SpeciesStageConfig? stageConfig = null;
+
+                if (
+                    createDto.SpeciesStageConfigId.HasValue
+                    && createDto.SpeciesStageConfigId.Value != Guid.Empty
+                )
                 {
-                    return Result<FarmingBatchDto>.Failure(
-                        "Không tìm thấy cấu hình cho loài và giai đoạn này",
-                        ResultType.BadRequest
+                    stageConfig = await stageConfigRepo.GetByIdAsync(
+                        createDto.SpeciesStageConfigId.Value
                     );
+
+                    if (stageConfig == null)
+                    {
+                        return Result<FarmingBatchDto>.Failure(
+                            "Không tìm thấy cấu hình cho loài và giai đoạn này",
+                            ResultType.BadRequest
+                        );
+                    }
+                }
+                else
+                {
+                    if (
+                        !createDto.SpeciesId.HasValue
+                        || createDto.SpeciesId.Value == Guid.Empty
+                    )
+                    {
+                        return Result<FarmingBatchDto>.Failure(
+                            "SpeciesStageConfigId là bắt buộc",
+                            ResultType.BadRequest
+                        );
+                    }
+
+                    if (
+                        !createDto.GrowthStageId.HasValue
+                        || createDto.GrowthStageId.Value == Guid.Empty
+                    )
+                    {
+                        return Result<FarmingBatchDto>.Failure(
+                            "SpeciesStageConfigId là bắt buộc",
+                            ResultType.BadRequest
+                        );
+                    }
+
+                    // Validate Species exists
+                    var speciesRepo = _unitOfWork.GetRepository<Species>();
+                    var speciesExists = await speciesRepo.AnyAsync(s =>
+                        s.Id == createDto.SpeciesId.Value
+                    );
+                    if (!speciesExists)
+                    {
+                        return Result<FarmingBatchDto>.Failure(
+                            "Loài cá không tồn tại",
+                            ResultType.BadRequest
+                        );
+                    }
+
+                    // Validate GrowthStage exists
+                    var growthStageRepo = _unitOfWork.GetRepository<GrowthStage>();
+                    var growthStageExists = await growthStageRepo.AnyAsync(gs =>
+                        gs.Id == createDto.GrowthStageId.Value
+                    );
+                    if (!growthStageExists)
+                    {
+                        return Result<FarmingBatchDto>.Failure(
+                            "Giai đoạn tăng trưởng không tồn tại",
+                            ResultType.BadRequest
+                        );
+                    }
+
+                    // Resolve SpeciesStageConfig from Species + GrowthStage
+                    stageConfig = await stageConfigRepo.FirstOrDefaultAsync(sc =>
+                        sc.SpeciesId == createDto.SpeciesId.Value
+                        && sc.GrowthStageId == createDto.GrowthStageId.Value
+                    );
+                    if (stageConfig == null)
+                    {
+                        return Result<FarmingBatchDto>.Failure(
+                            "Không tìm thấy cấu hình cho loài và giai đoạn này",
+                            ResultType.BadRequest
+                        );
+                    }
                 }
 
                 // Validate inputs


### PR DESCRIPTION
- Sửa lỗi tạo vụ nuôi mới khi bể đã có cá hoặc đang có lô nuôi hoạt động, API giờ trả 400/409 thay vì 500.
- Cập nhật CreateFarmingBatchDto để hỗ trợ đúng SpeciesStageConfigId mà frontend đang gửi.