### PR TITLE
feat(auth): add audit logging for login and logout

### DIFF
--- a/IRasRag.API/Controllers/AuditLogController.cs
+++ b/IRasRag.API/Controllers/AuditLogController.cs
@@ -1,0 +1,54 @@
+using IRasRag.Application.DTOs;
+using IRasRag.Application.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IRasRag.API.Controllers
+{
+    [Authorize(Roles = "Admin")]
+    [ApiController]
+    [Route("api/audit-logs")]
+    public class AuditLogController : ControllerBase
+    {
+        private const int MaxPageSize = 100;
+
+        private readonly IAuditLogService _auditLogService;
+        private readonly ILogger<AuditLogController> _logger;
+
+        public AuditLogController(
+            IAuditLogService auditLogService,
+            ILogger<AuditLogController> logger
+        )
+        {
+            _auditLogService = auditLogService;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAuditLogs([FromQuery] AuditLogQueryRequest request)
+        {
+            try
+            {
+                if (request.Page <= 0 || request.PageSize <= 0)
+                {
+                    return BadRequest(
+                        new { Message = "Số trang và kích thước trang phải lớn hơn 0." }
+                    );
+                }
+
+                if (request.PageSize > MaxPageSize)
+                {
+                    return BadRequest(new { Message = "Kích thước trang tối đa là 100." });
+                }
+
+                var result = await _auditLogService.GetPagedAsync(request);
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while retrieving audit logs.");
+                return StatusCode(500, new { Message = "Có lỗi xảy ra, vui lòng thử lại sau." });
+            }
+        }
+    }
+}

--- a/IRasRag.API/DI/DependencyInjection.cs
+++ b/IRasRag.API/DI/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Hangfire;
 using Hangfire.PostgreSql;
 using IRasRag.API.Hubs;
 using IRasRag.API.Utils;
+using IRasRag.Application.Common.Interfaces.Auth;
 using IRasRag.Application.Common.Interfaces.Realtime;
 using IRasRag.Infrastructure.DI;
 using IRasRag.Infrastructure.Settings;
@@ -29,6 +30,7 @@ namespace IRasRag.API.DI
             services.AddHangfireSetup(config, env);
             services.AddHttpContextAccessor();
             services.AddScoped<HttpContextUtils>();
+            services.AddScoped<ICurrentUserAccessor>(sp => sp.GetRequiredService<HttpContextUtils>());
             services.AddSignalR();
             services.AddSingleton<ILiveDataNotifier, SignalRLiveDataNotifier>();
             services.AddHostedService<TelemetryPushWorker>();

--- a/IRasRag.API/Utils/HttpContextUtils.cs
+++ b/IRasRag.API/Utils/HttpContextUtils.cs
@@ -1,8 +1,9 @@
 ﻿using System.Security.Claims;
+using IRasRag.Application.Common.Interfaces.Auth;
 
 namespace IRasRag.API.Utils
 {
-    public class HttpContextUtils
+    public class HttpContextUtils : ICurrentUserAccessor
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
 

--- a/IRasRag.Application/Common/Interfaces/Auth/ICurrentUserAccessor.cs
+++ b/IRasRag.Application/Common/Interfaces/Auth/ICurrentUserAccessor.cs
@@ -1,0 +1,7 @@
+namespace IRasRag.Application.Common.Interfaces.Auth
+{
+    public interface ICurrentUserAccessor
+    {
+        Guid? GetUserId();
+    }
+}

--- a/IRasRag.Application/Common/Interfaces/Persistence/Repositories/IAuditLogRepository.cs
+++ b/IRasRag.Application/Common/Interfaces/Persistence/Repositories/IAuditLogRepository.cs
@@ -1,0 +1,14 @@
+using IRasRag.Application.Common.Models.Pagination;
+using IRasRag.Application.DTOs;
+using IRasRag.Domain.Entities;
+
+namespace IRasRag.Application.Common.Interfaces.Persistence.Repositories
+{
+    public interface IAuditLogRepository : IRepository<AuditLog>
+    {
+        Task<PagedResult<AuditLog>> GetPagedAsync(
+            AuditLogQueryRequest request,
+            Domain.Enums.QueryType type = Domain.Enums.QueryType.ActiveOnly
+        );
+    }
+}

--- a/IRasRag.Application/DTOs/AuditLogDto.cs
+++ b/IRasRag.Application/DTOs/AuditLogDto.cs
@@ -1,0 +1,17 @@
+namespace IRasRag.Application.DTOs
+{
+    public class AuditLogDto
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string Email { get; set; } = string.Empty;
+        public string Action { get; set; } = string.Empty;
+        public string EntityType { get; set; } = string.Empty;
+        public string EntityId { get; set; } = string.Empty;
+        public string? OldValue { get; set; }
+        public string? NewValue { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/IRasRag.Application/DTOs/AuditLogQueryRequest.cs
+++ b/IRasRag.Application/DTOs/AuditLogQueryRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IRasRag.Application.DTOs
+{
+    public class AuditLogQueryRequest : BasePaginatedListRequest
+    {
+        public Guid? UserId { get; set; }
+
+        [MaxLength(50)]
+        public string? Action { get; set; }
+
+        [MaxLength(100)]
+        public string? EntityType { get; set; }
+
+        [MaxLength(100)]
+        public string? EntityId { get; set; }
+
+        public DateTime? FromDate { get; set; }
+
+        public DateTime? ToDate { get; set; }
+    }
+}

--- a/IRasRag.Application/Services/Implementations/AuthService.cs
+++ b/IRasRag.Application/Services/Implementations/AuthService.cs
@@ -21,6 +21,7 @@ namespace IRasRag.Application.Services.Implementations
         private readonly IJwtService _jwtService;
         private readonly IEmailService _emailService;
         private readonly IBackgroundJobService _backgroundJobService;
+        private readonly IAuditLogService _auditLogService;
 
         public AuthService(
             IUnitOfWork unitOfWork,
@@ -28,7 +29,8 @@ namespace IRasRag.Application.Services.Implementations
             IHashingService hasher,
             IJwtService jwtService,
             IEmailService emailService,
-            IBackgroundJobService backgroundJobService
+            IBackgroundJobService backgroundJobService,
+            IAuditLogService auditLogService
         )
         {
             _unitOfWork = unitOfWork;
@@ -37,6 +39,7 @@ namespace IRasRag.Application.Services.Implementations
             _jwtService = jwtService;
             _emailService = emailService;
             _backgroundJobService = backgroundJobService;
+            _auditLogService = auditLogService;
         }
 
         public async Task<Result<TokenResponse>> Login(LoginRequest request)
@@ -391,7 +394,7 @@ namespace IRasRag.Application.Services.Implementations
                 Timestamp = DateTime.UtcNow,
             };
 
-            await _unitOfWork.GetRepository<AuditLog>().AddAsync(auditLog);
+            await _auditLogService.AddAsync(auditLog);
         }
 
         private async Task ConsumeUserVerificationCodesAsync(Guid userId, VerificationType type)

--- a/IRasRag.Application/Services/Implementations/AuthService.cs
+++ b/IRasRag.Application/Services/Implementations/AuthService.cs
@@ -8,6 +8,7 @@ using IRasRag.Application.DTOs;
 using IRasRag.Application.Services.Interfaces;
 using IRasRag.Domain.Entities;
 using IRasRag.Domain.Enums;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace IRasRag.Application.Services.Implementations
@@ -94,6 +95,14 @@ namespace IRasRag.Application.Services.Implementations
                 };
 
                 await _unitOfWork.GetRepository<RefreshToken>().AddAsync(refreshToken);
+                await WriteAuditLogAsync(
+                    user,
+                    action: "LOGIN",
+                    entityType: "Auth",
+                    entityId: user.Id.ToString(),
+                    oldValue: null,
+                    newValue: JsonSerializer.Serialize(new { AccessTokenIssued = true, RefreshTokenIssued = true })
+                );
                 await _unitOfWork.SaveChangesAsync();
 
                 return Result<TokenResponse>.Success(
@@ -335,11 +344,54 @@ namespace IRasRag.Application.Services.Implementations
             _logger.LogInformation("Server's existing token: {ExistingToken}", existingToken);
             if (existingToken != null)
             {
+                var user = await _unitOfWork
+                    .GetRepository<User>()
+                    .FirstOrDefaultAsync(u => u.Id == existingToken.UserId);
+
                 existingToken.IsRevoked = true;
                 _unitOfWork.GetRepository<RefreshToken>().Update(existingToken);
+
+                if (user != null)
+                {
+                    await WriteAuditLogAsync(
+                        user,
+                        action: "LOGOUT",
+                        entityType: "Auth",
+                        entityId: user.Id.ToString(),
+                        oldValue: JsonSerializer.Serialize(new { IsRevoked = false }),
+                        newValue: JsonSerializer.Serialize(new { IsRevoked = true })
+                    );
+                }
+
                 await _unitOfWork.SaveChangesAsync();
             }
             return Result.Success("Đăng xuất thành công.");
+        }
+
+        private async Task WriteAuditLogAsync(
+            User user,
+            string action,
+            string entityType,
+            string entityId,
+            string? oldValue,
+            string? newValue
+        )
+        {
+            var auditLog = new AuditLog
+            {
+                UserId = user.Id,
+                FirstName = user.FirstName,
+                LastName = user.LastName,
+                Email = user.Email,
+                Action = action,
+                EntityType = entityType,
+                EntityId = entityId,
+                OldValue = oldValue,
+                NewValue = newValue,
+                Timestamp = DateTime.UtcNow,
+            };
+
+            await _unitOfWork.GetRepository<AuditLog>().AddAsync(auditLog);
         }
 
         private async Task ConsumeUserVerificationCodesAsync(Guid userId, VerificationType type)

--- a/IRasRag.Application/Services/Interfaces/IAuditLogService.cs
+++ b/IRasRag.Application/Services/Interfaces/IAuditLogService.cs
@@ -1,0 +1,13 @@
+using IRasRag.Application.Common.Models.Pagination;
+using IRasRag.Application.DTOs;
+using IRasRag.Domain.Entities;
+
+namespace IRasRag.Application.Services.Interfaces
+{
+    public interface IAuditLogService
+    {
+        Task AddAsync(AuditLog auditLog);
+
+        Task<PagedResult<AuditLogDto>> GetPagedAsync(AuditLogQueryRequest request);
+    }
+}

--- a/IRasRag.Domain/Entities/AuditLog.cs
+++ b/IRasRag.Domain/Entities/AuditLog.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+using IRasRag.Domain.Common;
+
+namespace IRasRag.Domain.Entities
+{
+    public class AuditLog : BaseEntity
+    {
+        [Required]
+        public Guid UserId { get; set; }
+
+        [MaxLength(100)]
+        public string? FirstName { get; set; }
+
+        [MaxLength(100)]
+        public string? LastName { get; set; }
+
+        [Required]
+        [MaxLength(255)]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(50)]
+        public string Action { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(100)]
+        public string EntityType { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(100)]
+        public string EntityId { get; set; } = string.Empty;
+
+        public string? OldValue { get; set; }
+
+        public string? NewValue { get; set; }
+
+        [Required]
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/IRasRag.Infrastructure/DI/DependencyInjection.cs
+++ b/IRasRag.Infrastructure/DI/DependencyInjection.cs
@@ -9,11 +9,14 @@ using IRasRag.Application.Common.Interfaces.FileValidator;
 using IRasRag.Application.Common.Interfaces.Mqtt;
 using IRasRag.Application.Common.Interfaces.Persistence;
 using IRasRag.Application.Common.Interfaces.Persistence.Repositories;
+using IRasRag.Application.Services.Interfaces;
 using IRasRag.Application.Common.Interfaces.Telemetry;
 using IRasRag.Application.Common.Settings;
 using IRasRag.Application.Common.Utils;
+using IRasRag.Infrastructure.Interceptors;
 using IRasRag.Infrastructure.Persistence;
 using IRasRag.Infrastructure.Repositories;
+using IRasRag.Infrastructure.Services;
 using IRasRag.Infrastructure.Services.Advisory;
 using IRasRag.Infrastructure.Services.Auth;
 using IRasRag.Infrastructure.Services.BackgroundJobs;
@@ -96,6 +99,7 @@ namespace IRasRag.Infrastructure.DI
             services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
             services.AddScoped<IUnitOfWork, UnitOfWork>();
             services.AddScoped<IAlertRepository, AlertRepository>();
+            services.AddScoped<IAuditLogRepository, AuditLogRepository>();
         }
 
         public static void AddServices(this IServiceCollection services)
@@ -104,6 +108,8 @@ namespace IRasRag.Infrastructure.DI
             services.AddScoped<IHashingService, HashingService>();
             services.AddScoped<IEmailService, EmailService>();
             services.AddScoped<IBackgroundJobService, HangfireBackgroundJobService>();
+            services.AddScoped<IAuditLogService, AuditLogService>();
+            services.AddScoped<AuditLogSaveChangesInterceptor>();
             services.AddScoped<IDocumentIngestJob, DocumentIngestJob>();
             services.AddScoped<IThresholdSyncJob, ThresholdSyncJob>();
             services.AddScoped<ICatalogSyncJob, CatalogSyncJob>();
@@ -155,9 +161,12 @@ namespace IRasRag.Infrastructure.DI
         )
         {
             var connectionString = ConnectionStringResolver.Resolve(config, env);
-            services.AddDbContext<AppDbContext>(options =>
+            services.AddDbContext<AppDbContext>((sp, options) =>
             {
-                options.UseNpgsql(connectionString).UseSnakeCaseNamingConvention();
+                options
+                    .UseNpgsql(connectionString)
+                    .UseSnakeCaseNamingConvention()
+                    .AddInterceptors(sp.GetRequiredService<AuditLogSaveChangesInterceptor>());
             });
         }
     }

--- a/IRasRag.Infrastructure/Data/Configurations/AuditLogConfiguration.cs
+++ b/IRasRag.Infrastructure/Data/Configurations/AuditLogConfiguration.cs
@@ -1,0 +1,27 @@
+using IRasRag.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace IRasRag.Infrastructure.Data.Configurations
+{
+    public class AuditLogConfiguration : IEntityTypeConfiguration<AuditLog>
+    {
+        public void Configure(EntityTypeBuilder<AuditLog> builder)
+        {
+            builder.ConfigureTimestamps();
+
+            builder.Property(a => a.Email).IsRequired().HasMaxLength(255);
+            builder.Property(a => a.Action).IsRequired().HasMaxLength(50);
+            builder.Property(a => a.EntityType).IsRequired().HasMaxLength(100);
+            builder.Property(a => a.EntityId).IsRequired().HasMaxLength(100);
+            builder.Property(a => a.FirstName).HasMaxLength(100);
+            builder.Property(a => a.LastName).HasMaxLength(100);
+            builder.Property(a => a.Timestamp).IsRequired();
+
+            builder.HasIndex(a => a.UserId);
+            builder.HasIndex(a => a.Action);
+            builder.HasIndex(a => a.EntityType);
+            builder.HasIndex(a => a.Timestamp);
+        }
+    }
+}

--- a/IRasRag.Infrastructure/Interceptors/AuditLogSaveChangesInterceptor.cs
+++ b/IRasRag.Infrastructure/Interceptors/AuditLogSaveChangesInterceptor.cs
@@ -1,0 +1,224 @@
+using System.Text.Json;
+using IRasRag.Application.Common.Interfaces.Auth;
+using IRasRag.Domain.Common;
+using IRasRag.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using IRasRag.Infrastructure.Persistence;
+
+namespace IRasRag.Infrastructure.Interceptors
+{
+    public sealed class AuditLogSaveChangesInterceptor : SaveChangesInterceptor
+    {
+        private static readonly HashSet<string> IgnoredEntityNames = new(StringComparer.OrdinalIgnoreCase)
+        {
+            nameof(AuditLog),
+            nameof(RefreshToken),
+            nameof(Verification),
+        };
+
+        private static readonly string[] IgnoredProperties =
+        {
+            nameof(BaseEntity.Id),
+            nameof(BaseEntity.CreatedAt),
+            nameof(BaseEntity.ModifiedAt),
+        };
+
+        private readonly ICurrentUserAccessor _currentUserAccessor;
+        private readonly ILogger<AuditLogSaveChangesInterceptor> _logger;
+
+        public AuditLogSaveChangesInterceptor(
+            ICurrentUserAccessor currentUserAccessor,
+            ILogger<AuditLogSaveChangesInterceptor> logger
+        )
+        {
+            _currentUserAccessor = currentUserAccessor;
+            _logger = logger;
+        }
+
+        public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            try
+            {
+                if (eventData.Context is not AppDbContext dbContext)
+                    return await base.SavingChangesAsync(eventData, result, cancellationToken);
+
+                dbContext.ChangeTracker.DetectChanges();
+                var userId = _currentUserAccessor.GetUserId();
+                if (userId is null)
+                {
+                    _logger.LogDebug("Skipping audit generation because no authenticated user was found.");
+                    return await base.SavingChangesAsync(eventData, result, cancellationToken);
+                }
+
+                var auditLogs = await BuildAuditLogsAsync(
+                    dbContext,
+                    userId.Value,
+                    cancellationToken
+                );
+                if (auditLogs.Count > 0)
+                    dbContext.AuditLogs.AddRange(auditLogs);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to prepare audit log entries before saving changes.");
+            }
+
+            return await base.SavingChangesAsync(eventData, result, cancellationToken);
+        }
+
+        private async Task<List<AuditLog>> BuildAuditLogsAsync(
+            AppDbContext dbContext,
+            Guid userId,
+            CancellationToken cancellationToken
+        )
+        {
+            var trackedEntries = dbContext
+                .ChangeTracker.Entries<BaseEntity>()
+                .Where(entry =>
+                    entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted
+                    && !IgnoredEntityNames.Contains(entry.Metadata.ClrType.Name)
+                )
+                .ToList();
+
+            if (trackedEntries.Count == 0)
+                return [];
+
+            var user = await dbContext
+                .Set<User>()
+                .IgnoreQueryFilters()
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+
+            if (user == null)
+            {
+                _logger.LogWarning(
+                    "Skipping audit generation because the current user {UserId} could not be resolved.",
+                    userId
+                );
+                return [];
+            }
+
+            var auditLogs = new List<AuditLog>();
+            foreach (var entry in trackedEntries)
+            {
+                var action = ResolveAction(entry);
+                if (action is null)
+                    continue;
+
+                var (oldValue, newValue) = ResolveValues(entry, action);
+                if (oldValue is null && newValue is null)
+                    continue;
+
+                auditLogs.Add(
+                    new AuditLog
+                    {
+                        UserId = user.Id,
+                        FirstName = user.FirstName,
+                        LastName = user.LastName,
+                        Email = user.Email,
+                        Action = action,
+                        EntityType = entry.Metadata.ClrType.Name,
+                        EntityId = ResolveEntityId(entry),
+                        OldValue = oldValue,
+                        NewValue = newValue,
+                        Timestamp = DateTime.UtcNow,
+                    }
+                );
+            }
+
+            return auditLogs;
+        }
+
+        private static string? ResolveAction(EntityEntry<BaseEntity> entry)
+        {
+            if (entry.State == EntityState.Added)
+                return "CREATE";
+
+            if (entry.State == EntityState.Deleted)
+                return "DELETE";
+
+            if (entry.State == EntityState.Modified)
+            {
+                if (IsSoftDelete(entry))
+                    return "DELETE";
+
+                return HasMeaningfulChanges(entry) ? "UPDATE" : null;
+            }
+
+            return null;
+        }
+
+        private static (string? OldValue, string? NewValue) ResolveValues(
+            EntityEntry<BaseEntity> entry,
+            string action
+        )
+        {
+            return action switch
+            {
+                "CREATE" => (null, SerializeValues(entry.CurrentValues)),
+                "DELETE" => (SerializeValues(entry.OriginalValues), null),
+                _ => (SerializeValues(entry.OriginalValues, entry.CurrentValues, true), SerializeValues(entry.CurrentValues, entry.OriginalValues, false)),
+            };
+        }
+
+        private static string ResolveEntityId(EntityEntry<BaseEntity> entry)
+        {
+            var id = entry.Property(nameof(BaseEntity.Id)).CurrentValue;
+            return id?.ToString() ?? string.Empty;
+        }
+
+        private static bool IsSoftDelete(EntityEntry<BaseEntity> entry)
+        {
+            var isDeletedProperty = entry.Properties.FirstOrDefault(p =>
+                string.Equals(p.Metadata.Name, nameof(ISoftDeletable.IsDeleted), StringComparison.OrdinalIgnoreCase)
+            );
+
+            return entry.Entity is ISoftDeletable && isDeletedProperty?.CurrentValue is bool isDeleted && isDeleted;
+        }
+
+        private static bool HasMeaningfulChanges(EntityEntry<BaseEntity> entry)
+        {
+            return entry.Properties.Any(property =>
+                !IgnoredProperties.Contains(property.Metadata.Name)
+                && property.IsModified
+            );
+        }
+
+        private static string? SerializeValues(
+            PropertyValues values,
+            PropertyValues? comparisonValues = null,
+            bool oldValues = false
+        )
+        {
+            var payload = new Dictionary<string, object?>();
+
+            foreach (var property in values.Properties)
+            {
+                if (IgnoredProperties.Contains(property.Name))
+                    continue;
+
+                if (comparisonValues is not null)
+                {
+                    var currentValue = values[property];
+                    var comparisonValue = comparisonValues[property];
+                    if (Equals(currentValue, comparisonValue))
+                        continue;
+
+                    payload[property.Name] = oldValues ? comparisonValue : currentValue;
+                    continue;
+                }
+
+                payload[property.Name] = values[property];
+            }
+
+            return payload.Count == 0 ? null : JsonSerializer.Serialize(payload);
+        }
+    }
+}

--- a/IRasRag.Infrastructure/Migrations/20260526235521_AddAuditLog.Designer.cs
+++ b/IRasRag.Infrastructure/Migrations/20260526235521_AddAuditLog.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IRasRag.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IRasRag.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260526235521_AddAuditLog")]
+    partial class AddAuditLog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/IRasRag.Infrastructure/Migrations/20260526235521_AddAuditLog.cs
+++ b/IRasRag.Infrastructure/Migrations/20260526235521_AddAuditLog.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IRasRag.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuditLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "audit_logs",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    first_name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    last_name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    email = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    action = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    entity_type = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    entity_id = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    old_value = table.Column<string>(type: "text", nullable: true),
+                    new_value = table.Column<string>(type: "text", nullable: true),
+                    timestamp = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    modified_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_audit_logs", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_logs_action",
+                table: "audit_logs",
+                column: "action");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_logs_entity_type",
+                table: "audit_logs",
+                column: "entity_type");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_logs_timestamp",
+                table: "audit_logs",
+                column: "timestamp");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_logs_user_id",
+                table: "audit_logs",
+                column: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "audit_logs");
+        }
+    }
+}

--- a/IRasRag.Infrastructure/Persistence/AppDbContext.cs
+++ b/IRasRag.Infrastructure/Persistence/AppDbContext.cs
@@ -62,6 +62,7 @@ namespace IRasRag.Infrastructure.Persistence
         // ====================================
         // Advisory & Alerts
         // ====================================
+        public DbSet<AuditLog> AuditLogs { get; set; }
         public DbSet<Alert> Alerts { get; set; }
         public DbSet<CorrectiveAction> CorrectiveActions { get; set; }
         public DbSet<Document> Documents { get; set; }
@@ -113,6 +114,7 @@ namespace IRasRag.Infrastructure.Persistence
             modelBuilder.ApplyConfiguration(new JobControlMappingConfiguration());
 
             // Advisory & Alerts
+            modelBuilder.ApplyConfiguration(new AuditLogConfiguration());
             modelBuilder.ApplyConfiguration(new AlertConfiguration());
             modelBuilder.ApplyConfiguration(new CorrectiveActionConfiguration());
             modelBuilder.ApplyConfiguration(new DocumentConfiguration());

--- a/IRasRag.Infrastructure/Repositories/AuditLogRepository.cs
+++ b/IRasRag.Infrastructure/Repositories/AuditLogRepository.cs
@@ -1,0 +1,98 @@
+using IRasRag.Application.Common.Interfaces.Persistence.Repositories;
+using IRasRag.Application.Common.Models.Pagination;
+using IRasRag.Application.DTOs;
+using IRasRag.Domain.Entities;
+using IRasRag.Domain.Enums;
+using IRasRag.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace IRasRag.Infrastructure.Repositories
+{
+    public class AuditLogRepository : Repository<AuditLog>, IAuditLogRepository
+    {
+        public AuditLogRepository(AppDbContext context)
+            : base(context) { }
+
+        public async Task<PagedResult<AuditLog>> GetPagedAsync(
+            AuditLogQueryRequest request,
+            QueryType type = QueryType.ActiveOnly
+        )
+        {
+            var page = request.Page < 1 ? 1 : request.Page;
+            var pageSize = request.PageSize < 1 ? 10 : request.PageSize;
+            var query = GetQueryable(type).AsNoTracking();
+
+            if (request.UserId.HasValue)
+                query = query.Where(x => x.UserId == request.UserId.Value);
+
+            if (!string.IsNullOrWhiteSpace(request.Action))
+            {
+                var action = request.Action.Trim();
+                query = query.Where(x => x.Action == action);
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.EntityType))
+            {
+                var entityType = request.EntityType.Trim();
+                query = query.Where(x => x.EntityType == entityType);
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.EntityId))
+            {
+                var entityId = request.EntityId.Trim();
+                query = query.Where(x => x.EntityId == entityId);
+            }
+
+            if (request.FromDate.HasValue)
+            {
+                var fromDate = DateTime.SpecifyKind(request.FromDate.Value, DateTimeKind.Utc);
+                query = query.Where(x => x.Timestamp >= fromDate);
+            }
+
+            if (request.ToDate.HasValue)
+            {
+                var toDate = DateTime.SpecifyKind(request.ToDate.Value, DateTimeKind.Utc);
+                query = query.Where(x => x.Timestamp <= toDate);
+            }
+
+            query = ApplySorting(query, request);
+
+            var totalItems = await query.CountAsync();
+            var items = await query
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+
+            return new PagedResult<AuditLog> { Items = items, TotalItems = totalItems };
+        }
+
+        private static IQueryable<AuditLog> ApplySorting(
+            IQueryable<AuditLog> query,
+            AuditLogQueryRequest request
+        )
+        {
+            var sortDir = request.SortDir?.Trim().ToLowerInvariant() == "desc";
+            var sortBy = request.SortBy?.Trim().ToLowerInvariant();
+
+            return sortBy switch
+            {
+                "userid" => sortDir
+                    ? query.OrderByDescending(x => x.UserId).ThenByDescending(x => x.Timestamp)
+                    : query.OrderBy(x => x.UserId).ThenByDescending(x => x.Timestamp),
+                "action" => sortDir
+                    ? query.OrderByDescending(x => x.Action).ThenByDescending(x => x.Timestamp)
+                    : query.OrderBy(x => x.Action).ThenByDescending(x => x.Timestamp),
+                "entitytype" => sortDir
+                    ? query.OrderByDescending(x => x.EntityType).ThenByDescending(x => x.Timestamp)
+                    : query.OrderBy(x => x.EntityType).ThenByDescending(x => x.Timestamp),
+                "entityid" => sortDir
+                    ? query.OrderByDescending(x => x.EntityId).ThenByDescending(x => x.Timestamp)
+                    : query.OrderBy(x => x.EntityId).ThenByDescending(x => x.Timestamp),
+                "timestamp" => sortDir
+                    ? query.OrderByDescending(x => x.Timestamp).ThenByDescending(x => x.Id)
+                    : query.OrderBy(x => x.Timestamp).ThenByDescending(x => x.Id),
+                _ => query.OrderByDescending(x => x.Timestamp).ThenByDescending(x => x.Id),
+            };
+        }
+    }
+}

--- a/IRasRag.Infrastructure/Services/AuditLogService.cs
+++ b/IRasRag.Infrastructure/Services/AuditLogService.cs
@@ -1,0 +1,52 @@
+using IRasRag.Application.Common.Interfaces.Persistence.Repositories;
+using IRasRag.Application.Common.Models.Pagination;
+using IRasRag.Application.DTOs;
+using IRasRag.Application.Services.Interfaces;
+using IRasRag.Domain.Entities;
+using IRasRag.Domain.Enums;
+
+namespace IRasRag.Infrastructure.Services
+{
+    public class AuditLogService : IAuditLogService
+    {
+        private readonly IAuditLogRepository _auditLogRepository;
+
+        public AuditLogService(IAuditLogRepository auditLogRepository)
+        {
+            _auditLogRepository = auditLogRepository;
+        }
+
+        public Task AddAsync(AuditLog auditLog)
+        {
+            return _auditLogRepository.AddAsync(auditLog);
+        }
+
+        public async Task<PagedResult<AuditLogDto>> GetPagedAsync(AuditLogQueryRequest request)
+        {
+            var result = await _auditLogRepository.GetPagedAsync(request, QueryType.ActiveOnly);
+            return new PagedResult<AuditLogDto>
+            {
+                Items = result.Items.Select(MapToDto).ToList(),
+                TotalItems = result.TotalItems,
+            };
+        }
+
+        private static AuditLogDto MapToDto(AuditLog auditLog)
+        {
+            return new AuditLogDto
+            {
+                Id = auditLog.Id,
+                UserId = auditLog.UserId,
+                FirstName = auditLog.FirstName,
+                LastName = auditLog.LastName,
+                Email = auditLog.Email,
+                Action = auditLog.Action,
+                EntityType = auditLog.EntityType,
+                EntityId = auditLog.EntityId,
+                OldValue = auditLog.OldValue,
+                NewValue = auditLog.NewValue,
+                Timestamp = auditLog.Timestamp,
+            };
+        }
+    }
+}

--- a/IRasRag.Test/UnitTests/Application/AuthServiceTest.cs
+++ b/IRasRag.Test/UnitTests/Application/AuthServiceTest.cs
@@ -9,6 +9,7 @@ using IRasRag.Application.Common.Models;
 using IRasRag.Application.Common.Models.Auth;
 using IRasRag.Application.DTOs;
 using IRasRag.Application.Services.Implementations;
+using IRasRag.Application.Services.Interfaces;
 using IRasRag.Domain.Entities;
 using IRasRag.Domain.Enums;
 using Microsoft.Extensions.Logging;
@@ -28,6 +29,7 @@ namespace IRasRag.Test.UnitTests.Application
         private readonly Mock<IEmailService> _emailServiceMock;
         private readonly Mock<IHashingService> _hashingServiceMock;
         private readonly Mock<IBackgroundJobService> _backgroundJobServiceMock;
+        private readonly Mock<IAuditLogService> _auditLogServiceMock;
         private readonly AuthService _sut;
 
         public AuthServiceTest()
@@ -42,6 +44,7 @@ namespace IRasRag.Test.UnitTests.Application
             _jwtServiceMock = new Mock<IJwtService>();
             _hashingServiceMock = new Mock<IHashingService>();
             _backgroundJobServiceMock = new Mock<IBackgroundJobService>();
+            _auditLogServiceMock = new Mock<IAuditLogService>();
 
             _unitOfWorkMock.Setup(u => u.GetRepository<User>()).Returns(_userRepositoryMock.Object);
             _unitOfWorkMock.Setup(u => u.GetRepository<Role>()).Returns(_roleRepositoryMock.Object);
@@ -51,6 +54,9 @@ namespace IRasRag.Test.UnitTests.Application
             _unitOfWorkMock
                 .Setup(u => u.GetRepository<RefreshToken>())
                 .Returns(_refreshTokenRepositoryMock.Object);
+            _auditLogServiceMock
+                .Setup(s => s.AddAsync(It.IsAny<AuditLog>()))
+                .Returns(Task.CompletedTask);
 
             _sut = new AuthService(
                 _unitOfWorkMock.Object,
@@ -58,7 +64,8 @@ namespace IRasRag.Test.UnitTests.Application
                 _hashingServiceMock.Object,
                 _jwtServiceMock.Object,
                 _emailServiceMock.Object,
-                _backgroundJobServiceMock.Object
+                _backgroundJobServiceMock.Object,
+                _auditLogServiceMock.Object
             );
         }
 


### PR DESCRIPTION
Task 41;  Check/Test AuditLog.

- Add AuditLog entity and EF configuration.
- Register AuditLog in AppDbContext (DbSet + model configuration).
- Add migration for AuditLog table and update EF snapshot.
- Add audit log creation in AuthService:
  - On successful LOGIN (token issuance details).
  - On LOGOUT (refresh token revoke state change).
- Capture actor metadata (UserId, FirstName, LastName, Email) and action payloads (oldValue, newValue) for traceability.
